### PR TITLE
Added 24bit color support and full pixel mode

### DIFF
--- a/cmdplaypp/src/Asciifier.cpp
+++ b/cmdplaypp/src/Asciifier.cpp
@@ -4,10 +4,11 @@
 #include <algorithm>
 
 cmdplay::Asciifier::Asciifier(const std::string& brightnessLevels, int frameWidth, int frameHeight, 
-	bool useColors, bool useColorDithering, bool useTextDithering, bool useAccurateColors) :
+	bool useColors, bool useColorDithering, bool useTextDithering, bool useAccurateColors, bool useAccurateColorsFullPixel) :
 	m_brightnessLevels(brightnessLevels), m_frameWidth(frameWidth), m_frameHeight(frameHeight),
 	m_useColorDithering(useColorDithering), m_useTextDithering(useTextDithering),
-	m_brightnessLevelCount(static_cast<uint8_t>(brightnessLevels.length())), m_useColors(useColors), m_useAccurateColors(useAccurateColors)
+	m_brightnessLevelCount(static_cast<uint8_t>(brightnessLevels.length())), m_useColors(useColors), 
+	m_useAccurateColors(useAccurateColors), m_useAccurateColorsFullPixel(useAccurateColorsFullPixel)
 {
 	if (m_useColors && m_useAccurateColors)
 	{
@@ -123,13 +124,18 @@ inline std::string cmdplay::Asciifier::ByteAsPaddedString(uint8_t i)
 {
 	std::string out = std::to_string(i);
 
-	// We want this number to be always 3 characters big (e.g. 4 => 004, 27 => 027; 174 => 174)
+	// We want this number to be always 3 characters wide (e.g. 4 => 004, 27 => 027; 174 => 174)
 	while (out.size() < 3)
 	{
 		out.insert(0, "0");
 	}
 
 	return out;
+}
+
+inline bool cmdplay::Asciifier::ColorComponentNearlyEquals(uint8_t value, uint8_t other)
+{
+	return std::abs(value - other) <= COLOR_BATCHING_TOLERANCE;
 }
 
 void cmdplay::Asciifier::ClearDitherErrors(float* buffer)
@@ -207,13 +213,42 @@ std::string cmdplay::Asciifier::BuildFrame(const uint8_t* rgbData)
 
 		if (m_useColors && m_useAccurateColors)
 		{
-			std::string outString = "\x1B[38;2;" + ByteAsPaddedString(rgbData[i]) + ";" + ByteAsPaddedString(rgbData[i + 1]) + ";" + ByteAsPaddedString(rgbData[i + 2]) + "m";
+			std::string outString;
+
+			// if the color we have last set rougly equals our current color, we don't set our new color to reduce the stress on the console color interpreter
+			if (ColorComponentNearlyEquals(rgbData[i], m_lastSetColor[0]) && ColorComponentNearlyEquals(rgbData[i + 1], m_lastSetColor[1]) && ColorComponentNearlyEquals(rgbData[i + 2], m_lastSetColor[2]))
+			{
+				outString = "\x1BX000000000000000\x1B\\"; // string message that the console ignores
+			}
+			else
+			{
+				if (m_useAccurateColorsFullPixel)
+				{
+					outString = "\x1B[48;2;" + ByteAsPaddedString(rgbData[i]) + ";" + ByteAsPaddedString(rgbData[i + 1]) + ";" + ByteAsPaddedString(rgbData[i + 2]) + "m";
+				}
+				else
+				{
+					outString = "\x1B[38;2;" + ByteAsPaddedString(rgbData[i]) + ";" + ByteAsPaddedString(rgbData[i + 1]) + ";" + ByteAsPaddedString(rgbData[i + 2]) + "m";
+				}
+				
+				m_lastSetColor[0] = rgbData[i];
+				m_lastSetColor[1] = rgbData[i + 1];
+				m_lastSetColor[2] = rgbData[i + 2];
+			}
+
 			for (int i = 0; i < outString.size(); ++i)
 			{
 				asciiDataArr[rowOffset + scanX + i] = outString.at(i);
 			}
 
-			asciiDataArr[rowOffset + scanX + outString.size()] = ToChar(brightnessIndex);
+			if (m_useAccurateColorsFullPixel)
+			{
+				asciiDataArr[rowOffset + scanX + outString.size()] = ' ';
+			}
+			else
+			{
+				asciiDataArr[rowOffset + scanX + outString.size()] = ToChar(brightnessIndex);
+			}
 		}
 		else if (m_useColors)
 		{

--- a/cmdplaypp/src/Asciifier.cpp
+++ b/cmdplaypp/src/Asciifier.cpp
@@ -247,7 +247,7 @@ std::string cmdplay::Asciifier::BuildFrame(const uint8_t* rgbData)
 			}
 			else
 			{
-				asciiDataArr[rowOffset + scanX + outString.size()] = ToChar(brightnessIndex);
+				asciiDataArr[rowOffset + scanX + outString.size()] = ToCharUnchecked(brightnessIndex);
 			}
 		}
 		else if (m_useColors)

--- a/cmdplaypp/src/Asciifier.hpp
+++ b/cmdplaypp/src/Asciifier.hpp
@@ -21,7 +21,7 @@ namespace cmdplay
 	{
 	public:
 		Asciifier(const std::string& brightnessLevels, int frameWidth, int frameHeight, 
-			bool useColors = true, bool useColorDithering = true, bool useTextDithering = true);
+			bool useColors = true, bool useColorDithering = true, bool useTextDithering = true, bool useAccurateColors = true);
 
 	private:
 		inline int16_t MapByteToArray(int16_t value);
@@ -30,6 +30,7 @@ namespace cmdplay
 		void InitColors();
 		inline std::string GetColor(uint8_t r, uint8_t g, uint8_t b);
 		inline std::string GetColorDithered(uint8_t r, uint8_t g, uint8_t b, int x, int y);
+		std::string ByteAsPaddedString(uint8_t i);
 		std::unique_ptr<float[]> m_hDitherErrors;
 		bool m_useColorDithering = false;
 		std::unique_ptr<float[]> m_textDitherErrors;
@@ -47,6 +48,7 @@ namespace cmdplay
 		bool m_useColors = false;
 		int m_pixelStride = 1;
 		int m_lastBrightnessError = 0;
+		bool m_useAccurateColors = false;
 
 	public:
 		std::string BuildFrame(const uint8_t* rgbData);

--- a/cmdplaypp/src/Asciifier.hpp
+++ b/cmdplaypp/src/Asciifier.hpp
@@ -16,12 +16,13 @@ namespace cmdplay
 	constexpr int DITHER_NEIGHBOR_BOTTOM_LEFT_FACTOR = 3;
 	constexpr int DITHER_NEIGHBOR_BOTTOM_FACTOR = 5;
 	constexpr int DITHER_NEIGHBOR_BOTTOM_RIGHT_FACTOR = 1;
+	constexpr uint8_t COLOR_BATCHING_TOLERANCE = 2;
 
 	class Asciifier
 	{
 	public:
 		Asciifier(const std::string& brightnessLevels, int frameWidth, int frameHeight, 
-			bool useColors = true, bool useColorDithering = true, bool useTextDithering = true, bool useAccurateColors = true);
+			bool useColors = true, bool useColorDithering = true, bool useTextDithering = true, bool useAccurateColors = true, bool useAccurateColorsFullPixel = true);
 
 	private:
 		inline int16_t MapByteToArray(int16_t value);
@@ -31,6 +32,7 @@ namespace cmdplay
 		inline std::string GetColor(uint8_t r, uint8_t g, uint8_t b);
 		inline std::string GetColorDithered(uint8_t r, uint8_t g, uint8_t b, int x, int y);
 		std::string ByteAsPaddedString(uint8_t i);
+		bool ColorComponentNearlyEquals(uint8_t value, uint8_t other);
 		std::unique_ptr<float[]> m_hDitherErrors;
 		bool m_useColorDithering = false;
 		std::unique_ptr<float[]> m_textDitherErrors;
@@ -49,6 +51,8 @@ namespace cmdplay
 		int m_pixelStride = 1;
 		int m_lastBrightnessError = 0;
 		bool m_useAccurateColors = false;
+		bool m_useAccurateColorsFullPixel = false;
+		uint8_t m_lastSetColor[3] = { 255, 255, 255 };
 
 	public:
 		std::string BuildFrame(const uint8_t* rgbData);

--- a/cmdplaypp/src/VideoPlayer.cpp
+++ b/cmdplaypp/src/VideoPlayer.cpp
@@ -18,7 +18,7 @@ void cmdplay::VideoPlayer::InitAsciifier()
 {
 	m_asciifier = std::make_unique<Asciifier>(m_brightnessLevels,
 		m_windowWidth, m_windowHeight, m_colorsEnabled,
-		m_colorDitheringEnabled, m_textDitheringEnabled, m_accurateColorsEnabled);
+		m_colorDitheringEnabled, m_textDitheringEnabled, m_accurateColorsEnabled, m_accurateColorsFullPixelEnabled);
 }
 
 void cmdplay::VideoPlayer::LoadVideo()
@@ -95,6 +95,12 @@ void cmdplay::VideoPlayer::Enter()
 					// Reset colors
 					std::cout << "\x1B[0m";
 				}
+				break;
+			}
+			case 'b':
+			{
+				m_accurateColorsFullPixelEnabled = !m_accurateColorsFullPixelEnabled;
+				InitAsciifier();
 				break;
 			}
 			case 't':

--- a/cmdplaypp/src/VideoPlayer.cpp
+++ b/cmdplaypp/src/VideoPlayer.cpp
@@ -18,7 +18,7 @@ void cmdplay::VideoPlayer::InitAsciifier()
 {
 	m_asciifier = std::make_unique<Asciifier>(m_brightnessLevels,
 		m_windowWidth, m_windowHeight, m_colorsEnabled,
-		m_colorDitheringEnabled, m_textDitheringEnabled);
+		m_colorDitheringEnabled, m_textDitheringEnabled, m_accurateColorsEnabled);
 }
 
 void cmdplay::VideoPlayer::LoadVideo()
@@ -80,6 +80,17 @@ void cmdplay::VideoPlayer::Enter()
 				m_colorsEnabled = !m_colorsEnabled;
 				InitAsciifier();
 				if (!m_colorsEnabled)
+				{
+					// Reset colors
+					std::cout << "\x1B[0m";
+				}
+				break;
+			}
+			case 'a':
+			{
+				m_accurateColorsEnabled = !m_accurateColorsEnabled;
+				InitAsciifier();
+				if (!m_accurateColorsEnabled)
 				{
 					// Reset colors
 					std::cout << "\x1B[0m";

--- a/cmdplaypp/src/VideoPlayer.hpp
+++ b/cmdplaypp/src/VideoPlayer.hpp
@@ -19,6 +19,7 @@ namespace cmdplay
 		int m_windowHeight = 0;
 		bool m_textDitheringEnabled = true;
 		bool m_colorsEnabled = false;
+		bool m_accurateColorsEnabled = false;
 		bool m_colorDitheringEnabled = true;
 		std::string m_filePath;
 		std::string m_brightnessLevels;

--- a/cmdplaypp/src/VideoPlayer.hpp
+++ b/cmdplaypp/src/VideoPlayer.hpp
@@ -20,6 +20,7 @@ namespace cmdplay
 		bool m_textDitheringEnabled = true;
 		bool m_colorsEnabled = false;
 		bool m_accurateColorsEnabled = false;
+		bool m_accurateColorsFullPixelEnabled = false;
 		bool m_colorDitheringEnabled = true;
 		std::string m_filePath;
 		std::string m_brightnessLevels;


### PR DESCRIPTION
As mentioned in the title above, this PR adds 24bit color mode (activate via A, needs to have color enabled) as well as full pixel support (activate via B, needs color and 24bit color enabled). Admittedly the full pixel mode doesn't really fit into the ascii-scheme anymore, but it's a cool addition anyways I guess. Interestingly while performance degrades with the 24 bit color mode, using the full pixel mode with it actually improves the performance again by a lot. I attached some example images down below.

### Default color
![default](https://github.com/mariiaan/cmdplay-pp/assets/16061683/a8a943a4-a923-439f-a0b9-fa5a2453d2bc)

### 24 bit color
![24bit](https://github.com/mariiaan/cmdplay-pp/assets/16061683/158ac54c-5bd7-4d0e-9b41-6fbb87eca3b4)

### 24 bit color with full pixel
![24bit_fullpixel](https://github.com/mariiaan/cmdplay-pp/assets/16061683/6465e848-56d0-4369-b34c-eb49276322f1)
